### PR TITLE
[feat] Added refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.4.1.alpha.2 - 10/03/2024
+
+### Added
+
+- **Auth Handler:** Added a new handler to handle refresh token requests. 
+
+### Changed
+
+- **Auth Query:** Updated the auth query from `registration_date` to `created_at`.
+  - ***Reason:*** This change was made to ensure that the correct field is used to store the registration date.
+  - ***Impact:*** This change will affect the database schema and the auth repository.
+- **Console Log:** Removed console logs from url_handler
+
 ## 0.4.1.alpha.1 - 10/03/2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.5.0 - 10/03/2024
+
+### Added
+
+- **Refresh Token Route:** Added a new route to the echo server to handle refresh token requests.
+
 ## 0.4.1.alpha.2 - 10/03/2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.4.1.alpha.1 - 10/03/2024
+
+### Added
+
+- **Refresh Token Test:** Added a test to ensure that the refresh token is generated.
+
+### Docs
+
+- **Postman Collection:** Added a postman collection to the project.
+
 ## 0.4.1 - 10/03/2024
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.5.1 - 10/03/2024
+
+### Added
+
+- **Empty Token Test:** Added a test to ensure that empty token are not sent to the server.
+
+### Changed
+
+- **Refactored Auth Repository Test:** Refactored the auth repository test to use the testify library for better assertions.
+
 ## 0.5.0 - 10/03/2024
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Code Style](https://img.shields.io/badge/code%20style-gofmt-%2300ADD8)](https://golang.org/doc/effective_go.html#formatting)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/abdullahkabakk/url-shortener/blob/main/LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/abdullahkabakk/url-shortener)](https://golang.org/doc/devel/release.html)
+[<img src="https://run.pstmn.io/button.svg" alt="Run In Postman" style="width: 128px; height: 32px;">](https://app.getpostman.com/run-collection/29774798-07fc0dc3-e608-40cc-bb6a-d9adf3248971?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D29774798-07fc0dc3-e608-40cc-bb6a-d9adf3248971%26entityType%3Dcollection%26workspaceId%3D108d3a9c-b63c-4312-b0f2-f9ec95727ae4)
 
 This project is a URL shortener built with Go and Echo framework, utilizing MySQL for data storage.
 

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -106,6 +106,39 @@
             }
           }
         }
+      },
+    },
+    "/auth/refresh-token/": {
+      "get": {
+        "summary": "Refresh user token",
+        "description": "Endpoint to refresh user token.",
+        "security": [
+          {
+            "Authorization": [
+              "schema": "#/definitions/UserToken"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token refreshed successfully",
+            "schema": {
+              "$ref": "#/definitions/UserToken"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
       }
     },
     "/url/shorten": {

--- a/internal/app/handlers/auth/auth_handler.go
+++ b/internal/app/handlers/auth/auth_handler.go
@@ -3,6 +3,7 @@ package auth_handler
 import (
 	"github.com/labstack/echo/v4"
 	"net/http"
+	"strings"
 	"url-shortener/internal/app/models/user"
 	"url-shortener/internal/app/services/auth"
 	"url-shortener/internal/app/services/token"
@@ -59,6 +60,37 @@ func (h *Handler) LoginUserHandler(c echo.Context) error {
 
 	// Generate a token for the authenticated auth
 	token, err := h.TokenRepository.GenerateToken(userVal)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"token": token})
+}
+
+// RefreshTokenHandler handles HTTP requests to refresh an auth token.
+func (h *Handler) RefreshTokenHandler(c echo.Context) error {
+	// Extract token from request headers or cookies
+	token := c.Request().Header.Get("Authorization")
+
+	// Initialize userID to nil
+	var userID *uint
+	// If token is provided, validate it and get the user ID
+	if token != "" {
+		parts := strings.Fields(token)
+		if len(parts) != 2 || parts[0] != "Bearer" {
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Invalid token"})
+		}
+		token = parts[1]
+		// Call the authentication service to validate the token and get the user ID
+		id, err := h.TokenRepository.ValidateToken(token)
+		if err != nil {
+			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Invalid token"})
+		}
+		userID = &id
+	}
+
+	// Generate a new token for the authenticated auth
+	token, err := h.TokenRepository.GenerateToken(&user_model.User{ID: *userID})
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}

--- a/internal/app/handlers/auth/auth_handler_test.go
+++ b/internal/app/handlers/auth/auth_handler_test.go
@@ -275,6 +275,23 @@ func TestRefreshTokenHandler(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("Should return error for empty token", func(t *testing.T) {
+		// Prepare a mock echo.Context with valid request body
+		req := httptest.NewRequest(http.MethodPost, userEndpoint+"refresh/", nil)
+		req.Header.Set(echo.HeaderAuthorization, "")
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+
+		// Call RefreshTokenHandler
+		err := userHandler.RefreshTokenHandler(c)
+
+		// Check the response
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), `{"error":"Token is required"}`)
+		assert.NoError(t, err)
+
+	})
+
 	t.Run("Should return error for expired token", func(t *testing.T) {
 		// Prepare a mock echo.Context with valid request body
 		req := httptest.NewRequest(http.MethodPost, userEndpoint+"refresh/", nil)

--- a/internal/app/handlers/url/url_handler.go
+++ b/internal/app/handlers/url/url_handler.go
@@ -1,7 +1,6 @@
 package url_handler
 
 import (
-	"fmt"
 	"github.com/labstack/echo/v4"
 	"net/http"
 	"net/url"
@@ -30,7 +29,6 @@ func (h *Handler) ShortenURLHandler(c echo.Context) error {
 
 	// Initialize userID to nil
 	var userID *uint
-	fmt.Println("token", token)
 	// If token is provided, validate it and get the user ID
 	if token != "" {
 		parts := strings.Fields(token)

--- a/internal/app/repositories/auth/auth_repository.go
+++ b/internal/app/repositories/auth/auth_repository.go
@@ -56,7 +56,7 @@ func (r *DBAuthRepository) Create(user *user_model.User) (*user_model.User, erro
 // GetByUsername retrieves an auth record from the database by username.
 func (r *DBAuthRepository) GetByUsername(username string) (*user_model.User, error) {
 	// Prepare SQL statement
-	query := "SELECT id, username, password, registration_date FROM users WHERE username = ?"
+	query := "SELECT id, username, password, created_at FROM users WHERE username = ?"
 	row := r.DB.QueryRow(query, username)
 
 	// Initialize a new User object to store the result

--- a/internal/app/repositories/auth/auth_repository_test.go
+++ b/internal/app/repositories/auth/auth_repository_test.go
@@ -119,9 +119,9 @@ func TestDBUserRepositoryGetByUsername(t *testing.T) {
 			RegistrationDate: time.Now(),
 		}
 
-		mock.ExpectQuery("SELECT id, username, password, registration_date FROM users").
+		mock.ExpectQuery("SELECT id, username, password, created_at FROM users").
 			WithArgs(username).
-			WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password", "registration_date"}).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password", "created_at"}).
 				AddRow(expectedUser.ID, expectedUser.Username, expectedUser.Password, expectedUser.RegistrationDate))
 
 		user, err := repo.GetByUsername(username)
@@ -133,7 +133,7 @@ func TestDBUserRepositoryGetByUsername(t *testing.T) {
 	})
 
 	t.Run("Failed to Get User (No Rows Returned)", func(t *testing.T) {
-		mock.ExpectQuery("SELECT id, username, password, registration_date FROM users").
+		mock.ExpectQuery("SELECT id, username, password, created_at FROM users").
 			WithArgs(username).
 			WillReturnError(sql.ErrNoRows)
 
@@ -146,9 +146,9 @@ func TestDBUserRepositoryGetByUsername(t *testing.T) {
 	})
 
 	t.Run("Failed to Get User (Scan Error)", func(t *testing.T) {
-		mock.ExpectQuery("SELECT id, username, password, registration_date FROM users").
+		mock.ExpectQuery("SELECT id, username, password, created_at FROM users").
 			WithArgs(username).
-			WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password", "registration_date"}).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password", "created_at"}).
 				AddRow(nil, nil, nil, nil))
 
 		user, err := repo.GetByUsername(username)

--- a/internal/infrastructure/http/server.go
+++ b/internal/infrastructure/http/server.go
@@ -64,6 +64,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func authRouter(group *echo.Group, userHandler *auth_handler.Handler) {
 	group.POST("/register/", userHandler.CreateUserHandler)
 	group.POST("/login/", userHandler.LoginUserHandler)
+	group.GET("/refresh-token/", userHandler.RefreshTokenHandler)
 }
 
 func urlRoute(group *echo.Group, urlHandler *url_handler.Handler) {

--- a/internal/mocks/token.go
+++ b/internal/mocks/token.go
@@ -22,6 +22,9 @@ func (mts *MockTokenService) GenerateToken(user *user_model.User) (string, error
 	if user.Username == "error_token" {
 		return "", user_model.ErrUserAlreadyExists
 	}
+	if user.ID == 0 {
+		return "", url_model.ErrInvalidToken
+	}
 	// For simplicity in testing, return a fixed token
 	return "mockToken", nil
 }
@@ -30,6 +33,9 @@ func (mts *MockTokenService) GenerateToken(user *user_model.User) (string, error
 func (mts *MockTokenService) ValidateToken(tokenString string) (uint, error) {
 	if tokenString == "invalid" {
 		return 0, url_model.ErrInvalidToken
+	}
+	if tokenString == "expired" {
+		return 0, nil
 	}
 	// For simplicity in testing, return a fixed user ID
 	return 123, nil

--- a/internal/mocks/token_test.go
+++ b/internal/mocks/token_test.go
@@ -11,7 +11,7 @@ func TestMockTokenService_GenerateToken(t *testing.T) {
 	mockTokenService := NewMockTokenService()
 
 	t.Run("Generate Token Successfully", func(t *testing.T) {
-		user := &user_model.User{Username: "testuser"}
+		user := &user_model.User{ID: 1, Username: "testuser"}
 		token, err := mockTokenService.GenerateToken(user)
 
 		assert.NoError(t, err)
@@ -25,6 +25,16 @@ func TestMockTokenService_GenerateToken(t *testing.T) {
 		assert.Error(t, err)
 		assert.Empty(t, token)
 		assert.Equal(t, user_model.ErrUserAlreadyExists, err)
+	})
+
+	t.Run("Invalid User", func(t *testing.T) {
+		user := &user_model.User{ID: 0}
+		token, err := mockTokenService.GenerateToken(user)
+
+		assert.Error(t, err)
+		assert.Empty(t, token)
+		assert.Equal(t, url_model.ErrInvalidToken, err)
+
 	})
 }
 
@@ -43,6 +53,12 @@ func TestMockTokenService_ValidateToken(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Equal(t, url_model.ErrInvalidToken, err)
+		assert.Zero(t, userID)
+	})
+	t.Run("Expired Token", func(t *testing.T) {
+		userID, err := mockTokenService.ValidateToken("expired")
+
+		assert.NoError(t, err)
 		assert.Zero(t, userID)
 	})
 }


### PR DESCRIPTION
- Added refresh token test
- Added Run In Postman option in README
- Auth Handler: Added a new handler to handle refresh token requests.
- Auth Query: Updated the auth query from `registration_date` to `created_at`.
  - Reason: This change was made to ensure that the correct field is used to store the registration date.
  - Impact: This change will affect the database schema and the auth repository.
- Console Log: Removed console logs from url_handler