### PR TITLE
[feat] Implemented Fetch User's URLs with token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.5.1.alpha.2 - 11/03/2024
+
+### Added
+
+- **Get User URL Functionality:** Added functionality to retrieve the user's URL.
+
+- **Mock URL Repository:** Added a mock URL repository to the project.
+
 ## 0.5.1.alpha.1 - 11/03/2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.6.0 - 11/03/2024
+
+### Added
+
+- **User's URL Endpoint:** Added a new route to the echo server to handle the user's URL.
+
 ## 0.5.1.alpha.2 - 11/03/2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.5.1.alpha.1 - 11/03/2024
+
+### Added
+
+- **Get User URL Test:** Added a test to ensure that the user's URL is retrieved.
+
+### Changed
+
+- **Parse Time:** Updated the parse time for database.
+
+- **Renamed RegistrationDate to CreatedAt:** Renamed the `registration_date` field to `created_at` in the user model.
+
+- **Renamed CreationDate to CreatedAt:** Renamed the `creation_date` field to `created_at` in the click model.
+
 ## 0.5.1 - 10/03/2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All significant updates to this project will be meticulously documented in this log.
 
+## 0.6.1 - 11/03/2024
+
+### Changed
+
+- **Error handling:** Added error handling for create_url in tests
+
 ## 0.6.0 - 11/03/2024
 
 ### Added

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -191,6 +191,39 @@
         }
       },
     },
+    "/url/": {
+      "get": {
+        "summary": "Get User URLs",
+        "description": "Endpoint to get all URLs of the user.",
+        "security": [
+          {
+            "Authorization": [
+              "schema": "#/definitions/UserToken"
+            ],
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User URLs retrieved successfully",
+            "schema": {
+              "$ref": "#/definitions/URLData"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+    },
     "/clicks/{id}": {
       "get": {
         "summary": "Redirect to original URL",

--- a/internal/app/handlers/url/url_handler_test.go
+++ b/internal/app/handlers/url/url_handler_test.go
@@ -176,7 +176,10 @@ func TestUserUrlHandlers(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c := echo.New().NewContext(req, rec)
 		user := uint(1)
-		mockRepository.CreateURL("https://www.example.com", "abc123", &user)
+		_, err := mockRepository.CreateURL("https://www.example.com", "abc123", &user)
+		if err != nil {
+			return
+		}
 		token, err := tokenService.GenerateToken(&user_model.User{ID: 1})
 		if err != nil {
 			return

--- a/internal/app/handlers/url/url_handler_test.go
+++ b/internal/app/handlers/url/url_handler_test.go
@@ -152,3 +152,84 @@ func TestShortenUrlHandler(t *testing.T) {
 	})
 
 }
+
+func TestUserUrlHandlers(t *testing.T) {
+	mockRepository := mocks.NewMockUrlRepository()
+	mockService := url_service.NewURLService(mockRepository)
+	tokenService := mocks.NewMockTokenService()
+	mockHandler := NewURLHandler(mockService, tokenService)
+
+	t.Run("Should return error if token is not provided", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, urlEndpoint, nil)
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+
+		err := mockHandler.GetUserUrlsHandler(c)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), "error")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Should return user urls", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, urlEndpoint, nil)
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+		user := uint(1)
+		mockRepository.CreateURL("https://www.example.com", "abc123", &user)
+		token, err := tokenService.GenerateToken(&user_model.User{ID: 1})
+		if err != nil {
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		err = mockHandler.GetUserUrlsHandler(c)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Should return error for user not having any urls", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, urlEndpoint, nil)
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+		token, err := tokenService.GenerateToken(&user_model.User{ID: 2})
+		if err != nil {
+			return
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		err = mockHandler.GetUserUrlsHandler(c)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Contains(t, rec.Body.String(), "error")
+		assert.NoError(t, err)
+
+	})
+
+	t.Run("Should return error for invalid token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, urlEndpoint, nil)
+		req.Header.Set("Authorization", "invalid")
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+
+		err := mockHandler.GetUserUrlsHandler(c)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), "error")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Should return error for invalid token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, urlEndpoint, nil)
+		req.Header.Set("Authorization", "Bearer invalid")
+		rec := httptest.NewRecorder()
+		c := echo.New().NewContext(req, rec)
+
+		err := mockHandler.GetUserUrlsHandler(c)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Contains(t, rec.Body.String(), "error")
+		assert.NoError(t, err)
+	})
+}

--- a/internal/app/models/url/url.go
+++ b/internal/app/models/url/url.go
@@ -16,5 +16,5 @@ type URL struct {
 	OriginalURL  string    `json:"original_url"`
 	ShortenedURL string    `json:"shortened_url"`
 	UserID       uint      `json:"user_id"`
-	CreationDate time.Time `json:"creation_date"`
+	CreatedAt    time.Time `json:"created_at"`
 }

--- a/internal/app/models/user/user.go
+++ b/internal/app/models/user/user.go
@@ -10,8 +10,8 @@ var ErrUserAlreadyExists = errors.New("auth already exists")
 
 // User represents an auth entity in the application.
 type User struct {
-	ID               uint      `json:"id"`
-	Username         string    `json:"username"`
-	Password         string    `json:"password"`
-	RegistrationDate time.Time `json:"registration_date"`
+	ID        uint      `json:"id"`
+	Username  string    `json:"username"`
+	Password  string    `json:"password"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/app/repositories/auth/auth_repository.go
+++ b/internal/app/repositories/auth/auth_repository.go
@@ -63,7 +63,7 @@ func (r *DBAuthRepository) GetByUsername(username string) (*user_model.User, err
 	user := &user_model.User{}
 
 	// Scan the result into the User object
-	err := row.Scan(&user.ID, &user.Username, &user.Password, &user.RegistrationDate)
+	err := row.Scan(&user.ID, &user.Username, &user.Password, &user.CreatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// Return a custom error if the auth with the specified username is not found

--- a/internal/app/repositories/auth/auth_repository_test.go
+++ b/internal/app/repositories/auth/auth_repository_test.go
@@ -113,16 +113,16 @@ func TestDBUserRepositoryGetByUsername(t *testing.T) {
 
 	t.Run("Get User Successfully", func(t *testing.T) {
 		expectedUser := &user_model.User{
-			ID:               1,
-			Username:         username,
-			Password:         "password123",
-			RegistrationDate: time.Now(),
+			ID:        1,
+			Username:  username,
+			Password:  "password123",
+			CreatedAt: time.Now(),
 		}
 
 		mock.ExpectQuery("SELECT id, username, password, created_at FROM users").
 			WithArgs(username).
 			WillReturnRows(sqlmock.NewRows([]string{"id", "username", "password", "created_at"}).
-				AddRow(expectedUser.ID, expectedUser.Username, expectedUser.Password, expectedUser.RegistrationDate))
+				AddRow(expectedUser.ID, expectedUser.Username, expectedUser.Password, expectedUser.CreatedAt))
 
 		user, err := repo.GetByUsername(username)
 

--- a/internal/app/services/url/url_service.go
+++ b/internal/app/services/url/url_service.go
@@ -1,6 +1,7 @@
 package url_service
 
 import (
+	url_model "url-shortener/internal/app/models/url"
 	"url-shortener/internal/app/repositories/url"
 	"url-shortener/internal/utils"
 )
@@ -38,4 +39,15 @@ func (s *Service) GetOriginalURL(shortURL string) (string, error) {
 	}
 
 	return originalURL, nil
+}
+
+// GetUserURLs retrieves the URLs created by the given user.
+func (s *Service) GetUserURLs(userID uint) ([]url_model.URL, error) {
+	// Retrieve the URLs from the repository
+	urls, err := s.Repository.GetUserURLs(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return urls, nil
 }

--- a/internal/app/services/url/url_service_test.go
+++ b/internal/app/services/url/url_service_test.go
@@ -58,7 +58,10 @@ func TestGetUserUrls(t *testing.T) {
 
 	t.Run("Get User URLs Successfully", func(t *testing.T) {
 		user := uint(1)
-		mockRepo.CreateURL("https://www.example.com", "abc123", &user)
+		_, err := mockRepo.CreateURL("https://www.example.com", "abc123", &user)
+		if err != nil {
+			return
+		}
 		urls, err := urlService.GetUserURLs(1)
 		if err != nil {
 			t.Errorf("Error: %s", err)

--- a/internal/app/services/url/url_service_test.go
+++ b/internal/app/services/url/url_service_test.go
@@ -1,6 +1,7 @@
 package url_service
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"url-shortener/internal/mocks"
@@ -48,4 +49,27 @@ func TestGetOriginalURL(t *testing.T) {
 		_, err := urlService.GetOriginalURL("nonexistent")
 		assert.Error(t, err)
 	})
+}
+
+func TestGetUserUrls(t *testing.T) {
+	mockRepo := mocks.NewMockUrlRepository()
+
+	urlService := NewURLService(mockRepo)
+
+	t.Run("Get User URLs Successfully", func(t *testing.T) {
+		user := uint(1)
+		mockRepo.CreateURL("https://www.example.com", "abc123", &user)
+		urls, err := urlService.GetUserURLs(1)
+		if err != nil {
+			t.Errorf("Error: %s", err)
+		}
+		fmt.Println(urls)
+		assert.NotEmpty(t, urls)
+	})
+
+	t.Run("Should return error for nonexistent user", func(t *testing.T) {
+		_, err := urlService.GetUserURLs(2)
+		assert.Error(t, err)
+	})
+
 }

--- a/internal/infrastructure/database/database.go
+++ b/internal/infrastructure/database/database.go
@@ -22,7 +22,7 @@ type DBConnector struct {
 
 // Connect establishes a connection to the MySQL database using the provided credentials and driver name.
 func (m *DBConnector) Connect(driverName string) (*sql.DB, error) {
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/", m.Username, m.Password, m.Host, m.Port)
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/?parseTime=true", m.Username, m.Password, m.Host, m.Port)
 	db, err := sql.Open(driverName, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("[DB Connection] Failed to connect to Database: %w", err)

--- a/internal/infrastructure/http/server.go
+++ b/internal/infrastructure/http/server.go
@@ -69,6 +69,7 @@ func authRouter(group *echo.Group, userHandler *auth_handler.Handler) {
 
 func urlRoute(group *echo.Group, urlHandler *url_handler.Handler) {
 	group.POST("/shorten/", urlHandler.ShortenURLHandler)
+	group.GET("/", urlHandler.GetUserUrlsHandler)
 }
 
 func clicksRoute(group *echo.Group, clickHandler *clicks_handler.Handler) {

--- a/internal/mocks/token.go
+++ b/internal/mocks/token.go
@@ -25,6 +25,9 @@ func (mts *MockTokenService) GenerateToken(user *user_model.User) (string, error
 	if user.ID == 0 {
 		return "", url_model.ErrInvalidToken
 	}
+	if user.ID == 2 {
+		return "2", nil
+	}
 	// For simplicity in testing, return a fixed token
 	return "mockToken", nil
 }
@@ -36,6 +39,9 @@ func (mts *MockTokenService) ValidateToken(tokenString string) (uint, error) {
 	}
 	if tokenString == "expired" {
 		return 0, nil
+	}
+	if tokenString == "mockToken" {
+		return 1, nil
 	}
 	// For simplicity in testing, return a fixed user ID
 	return 123, nil

--- a/internal/mocks/token_test.go
+++ b/internal/mocks/token_test.go
@@ -36,6 +36,15 @@ func TestMockTokenService_GenerateToken(t *testing.T) {
 		assert.Equal(t, url_model.ErrInvalidToken, err)
 
 	})
+
+	t.Run("User with ID 2", func(t *testing.T) {
+		user := &user_model.User{ID: 2}
+		token, err := mockTokenService.GenerateToken(user)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "2", token)
+
+	})
 }
 
 func TestMockTokenService_ValidateToken(t *testing.T) {
@@ -60,5 +69,12 @@ func TestMockTokenService_ValidateToken(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Zero(t, userID)
+	})
+
+	t.Run("Valid Token", func(t *testing.T) {
+		userID, err := mockTokenService.ValidateToken("mockToken")
+
+		assert.NoError(t, err)
+		assert.Equal(t, uint(1), userID)
 	})
 }

--- a/internal/mocks/url.go
+++ b/internal/mocks/url.go
@@ -29,10 +29,17 @@ func (r *MockUrlRepository) CreateURL(originalUrl, shortCode string, userId *uin
 		}
 	}
 
+	var userID uint
+	if userId != nil {
+		userID = *userId
+	}
+
 	url := &url_model.URL{
 		OriginalURL:  originalUrl,
 		ShortenedURL: shortCode,
+		UserID:       userID,
 	}
+
 	r.Urls[uint(len(r.Urls)+1)] = url
 	return shortCode, nil
 }
@@ -53,4 +60,18 @@ func (r *MockUrlRepository) GetOriginalURL(shortCode string) (string, error) {
 	}
 	// Return an error if url not found
 	return "", url_model.ErrURLNotFound
+}
+
+// GetUserURLs simulates retrieving all urls created by a user from the mock database.
+func (r *MockUrlRepository) GetUserURLs(userId uint) ([]url_model.URL, error) {
+	urls := make([]url_model.URL, 0)
+	for _, u := range r.Urls {
+		if u.UserID == userId {
+			urls = append(urls, *u)
+		}
+	}
+	if len(urls) == 0 {
+		return nil, url_model.ErrURLNotFound
+	}
+	return urls, nil
 }

--- a/internal/mocks/url_test.go
+++ b/internal/mocks/url_test.go
@@ -63,7 +63,10 @@ func TestMockUrlRepository_GetOriginalURL(t *testing.T) {
 func TestMockUrlRepository_GetUserUrls(t *testing.T) {
 	repo := NewMockUrlRepository()
 	userID := uint(1)
-	repo.CreateURL("https://www.example.com", "abc123", &userID)
+	_, err := repo.CreateURL("https://www.example.com", "abc123", &userID)
+	if err != nil {
+		return
+	}
 
 	t.Run("Success", func(t *testing.T) {
 		urls, err := repo.GetUserURLs(userID)

--- a/internal/mocks/url_test.go
+++ b/internal/mocks/url_test.go
@@ -59,3 +59,21 @@ func TestMockUrlRepository_GetOriginalURL(t *testing.T) {
 		assert.Equal(t, "https://www.google.com", originalURL)
 	})
 }
+
+func TestMockUrlRepository_GetUserUrls(t *testing.T) {
+	repo := NewMockUrlRepository()
+	userID := uint(1)
+	repo.CreateURL("https://www.example.com", "abc123", &userID)
+
+	t.Run("Success", func(t *testing.T) {
+		urls, err := repo.GetUserURLs(userID)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, urls)
+	})
+
+	t.Run("Error - User not found", func(t *testing.T) {
+		urls, err := repo.GetUserURLs(2)
+		assert.Error(t, err)
+		assert.Empty(t, urls)
+	})
+}


### PR DESCRIPTION
- Get User URL Test: Added a test to ensure that the user's URL is retrieved.
- Parse Time: Updated the parse time for database.
- Renamed RegistrationDate to CreatedAt: Renamed the `registration_date` field to `created_at` in the user model.
- Renamed CreationDate to CreatedAt: Renamed the `creation_date` field to `created_at` in the click model.
- Get User URL Functionality: Added functionality to retrieve the user's URL.
- Mock URL Repository: Added a mock URL repository to the project.
- User's URL Endpoint: Added a new route to the echo server to handle the user's URL.
